### PR TITLE
Fixes issue presented in #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ embeded into react render functions.
 [Demo app](https://github.com/whatisinternet/react-svg-demo)
 
 ## TODO:
-- Only write out if within a valid attribute
 - Write to something other than std::out
 - Return warnings on failed tags
 - Config options for passing in supported tags, and attributes

--- a/src/parser/attribute.rs
+++ b/src/parser/attribute.rs
@@ -6,13 +6,29 @@ use parser::util::*;
 
 fn valid_react_attribute(test_element: &str) -> bool {
     let valid_react_attributes= [
-"width", "height", "style", "clipPath", "cx", "cy", "d", "dx", "dy", "fill", "fillOpacity", "fontFamily",
+"clipPath", "cx", "cy", "d", "dx", "dy", "fill", "fillOpacity", "fontFamily",
 "fontSize", "fx", "fy", "gradientTransform", "gradientUnits", "markerEnd",
 "markerMid", "markerStart", "offset", "opacity", "patternContentUnits",
 "patternUnits", "points", "preserveAspectRatio", "r", "rx", "ry",
 "spreadMethod", "stopColor", "stopOpacity", "stroke", "strokeDasharray",
 "strokeLinecap", "strokeOpacity", "strokeWidth", "textAnchor", "transform",
-"version", "viewBox", "x1", "x2", "x", "y1", "y2", "y"
+"version", "viewBox", "x1", "x2", "x", "y1", "y2", "y",
+"accept", "acceptCharset", "accessKey", "action", "allowFullScreen",
+"allowTransparency", "alt", "async", "autoComplete", "autoFocus", "autoPlay",
+"cellPadding", "cellSpacing", "charSet", "checked", "classID", "className",
+"colSpan", "cols", "content", "contentEditable", "contextMenu", "controls",
+"coords", "crossOrigin", "data", "dateTime", "defer", "dir", "disabled",
+"download", "draggable", "encType", "form", "formAction", "formEncType",
+"formMethod", "formNoValidate", "formTarget", "frameBorder", "headers",
+"height", "hidden", "high", "href", "hrefLang", "htmlFor", "httpEquiv", "icon",
+"id", "label", "lang", "list", "loop", "low", "manifest", "marginHeight",
+"marginWidth", "max", "maxLength", "media", "mediaGroup", "method", "min",
+"multiple", "muted", "name", "noValidate", "open", "optimum", "pattern",
+"placeholder", "poster", "preload", "radioGroup", "readOnly", "rel", "required",
+"role", "rowSpan", "rows", "sandbox", "scope", "scoped", "scrolling",
+"seamless", "selected", "shape", "size", "sizes", "span", "spellCheck", "src",
+"srcDoc", "srcSet", "start", "step", "style", "tabIndex", "target", "title",
+"type", "useMap", "value", "width", "wmode"
 ];
     return valid_react_attributes.contains(&test_element)
 }

--- a/src/parser/element.rs
+++ b/src/parser/element.rs
@@ -12,12 +12,15 @@ fn valid_react_dom_element (test_element: &str) -> bool {
 
 pub fn build_element(name: xml::name::OwnedName,
                  attributes: Vec<xml::attribute::OwnedAttribute>,
-                 depth: usize) {
+                 depth: usize) -> bool{
 
     let temp_name: String = format!("{}", name);
     let svg_tag: String = parse_off_extra_w3c_details(temp_name);
     if valid_react_dom_element(&svg_tag) {
         println!("{}React.DOM.{}", tab_in(depth), svg_tag);
         build_attributes(attributes.clone(), depth);
+        return true
+    } else {
+        return false
     }
 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -18,14 +18,10 @@ pub fn parse_svg (file_name: String){
         match e {
             XmlEvent::StartElement { name, attributes, .. } => {
                 was_valid_element = build_element(name, attributes, depth);
-                if was_valid_element {
-                    depth += 1;
-                }
+                depth += 1;
             }
             XmlEvent::EndElement { .. } => {
-                if was_valid_element {
-                    depth -= 1;
-                }
+                depth -= 1;
             }
             XmlEvent::Characters(data) => {
                 if was_valid_element {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -13,21 +13,28 @@ pub fn parse_svg (file_name: String){
     let mut parser = EventReader::new(file);
 
     let mut depth = 2;
+    let mut was_valid_element = false;
     for e in parser.events() {
         match e {
             XmlEvent::StartElement { name, attributes, .. } => {
-                build_element(name, attributes, depth);
-                depth += 1;
+                was_valid_element = build_element(name, attributes, depth);
+                if was_valid_element {
+                    depth += 1;
+                }
             }
             XmlEvent::EndElement { .. } => {
-                depth -= 1;
+                if was_valid_element {
+                    depth -= 1;
+                }
             }
             XmlEvent::Characters(data) => {
-                depth += 1;
-                if !data.contains(">") {
-                    println!("{}\"{}\"\n\n", tab_in(depth), data.to_string());
+                if was_valid_element {
+                    depth += 1;
+                    if !data.contains(">") {
+                        println!("{}\"{}\"\n\n", tab_in(depth), data.to_string());
+                    }
+                    depth -= 1;
                 }
-                depth -= 1;
             }
             _ => {}
         }


### PR DESCRIPTION
Fixes issue #3 with properties still getting printed when they shouldn't.

``` xml
...
<invalidDOM>
    Invalid String
</invalidDOM>
...
```

Did result in

``` coffee
...
    ,
    "Invalid String"
...
```

Results in

``` coffee
...
```
