### PR TITLE
Remove std::out as the default output for the lib portion of the package.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "svg_to_react_coffee"
 version = "0.2.0"
 dependencies = [
  "case 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -14,6 +15,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "case"
 version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,12 @@ repository ="https://github.com/whatisinternet/svg_to_react_coffee"
 readme = "README.md"
 keywords = ["svg", "react", "coffeescript"]
 
+[xlib]
+name = "svg_to_react"
+path = "lib/lib.rs"
+
 [lib]
-crate_type= ["dylib"]
+crate_type= ["dylib", "rlib"]
 name = "svg_to_react"
 path = "lib/lib.rs"
 
@@ -18,5 +22,6 @@ name = "svg_to_react_bin"
 path = "src/main.rs"
 
 [dependencies]
+libc = "0.1"
 xml-rs = "0.1.25"
 case = "0.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,6 @@ repository ="https://github.com/whatisinternet/svg_to_react_coffee"
 readme = "README.md"
 keywords = ["svg", "react", "coffeescript"]
 
-[xlib]
-name = "svg_to_react"
-path = "lib/lib.rs"
-
 [lib]
 crate_type= ["dylib", "rlib"]
 name = "svg_to_react"

--- a/README.md
+++ b/README.md
@@ -11,12 +11,11 @@ embeded into react render functions.
 ## TODO:
 
 ### Library features
-- Write to something other than std::out
 - TESTS!
 - Return warnings on failed tags
+- Config options for passing in supported tags, and attributes
 
 ### Binary features
-- Config options for passing in supported tags, and attributes
 - Possibly split off HTML renderer as related project
 
 ## Installation:
@@ -25,7 +24,8 @@ embeded into react render functions.
 
 1. Install [Rust and cargo](http://doc.crates.io/)
 2. git clone git@github.com:whatisinternet/svg_to_react_coffee.git
-3. cd svg_to_react_coffee && cargo build --release
+3. Library: cd svg_to_react_coffee && cargo build --release --lib
+3. Executable: cd svg_to_react_coffee && cargo build --release --lib && cargo build --release --bin svg_to_react_bin
 4. You can find the executable in target/release
 
 ## Usage:

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -9,8 +9,8 @@ use parser::parser::*;
 #[no_mangle]
 pub extern "C" fn convert(svg_file_name: String) {
   let file_name: Vec<&str> = svg_file_name.split(".svg").collect();
-  println!("module.exports = React.createFactory React.createClass\n\n  render: ->");
+  let mut header_string: String = format!("module.exports = React.createFactory React.createClass\n\n  render: ->");
   if file_name.len() > 1 {
-    parse_svg(svg_file_name.clone());
+    parse_svg(svg_file_name.clone(), header_string.clone());
   }
 }

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -7,10 +7,11 @@ mod file_loading;
 use parser::parser::*;
 
 #[no_mangle]
-pub extern "C" fn convert(svg_file_name: String) {
+pub extern "C" fn convert(svg_file_name: String) -> Vec<String> {
   let file_name: Vec<&str> = svg_file_name.split(".svg").collect();
   let header_string: String = format!("module.exports = React.createFactory React.createClass\n\n  render: ->");
   if file_name.len() > 1 {
-    parse_svg(svg_file_name.clone(), header_string.clone());
+    return parse_svg(svg_file_name.clone(), header_string.clone());
   }
+  return vec!();
 }

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -9,7 +9,7 @@ use parser::parser::*;
 #[no_mangle]
 pub extern "C" fn convert(svg_file_name: String) {
   let file_name: Vec<&str> = svg_file_name.split(".svg").collect();
-  let mut header_string: String = format!("module.exports = React.createFactory React.createClass\n\n  render: ->");
+  let header_string: String = format!("module.exports = React.createFactory React.createClass\n\n  render: ->");
   if file_name.len() > 1 {
     parse_svg(svg_file_name.clone(), header_string.clone());
   }

--- a/lib/parser/attribute.rs
+++ b/lib/parser/attribute.rs
@@ -6,20 +6,27 @@ use parser::util::tab_in;
 use parser::util::parse_off_extra_w3c_details;
 use parser::util::valid_react_attribute;
 
-pub fn build_attributes(attributes: Vec<xml::attribute::OwnedAttribute>, depth: usize) {
+pub fn build_attributes(
+    attributes: Vec<xml::attribute::OwnedAttribute>,
+    depth: usize) -> Vec<String> {
+
+    let mut element_attributes: Vec<String> = vec!();
     for attribute in attributes{
-        print_valid_attribute( depth, attribute )
+        let valid_attribute: String = valid_attribute( depth, attribute ).to_string();
+        element_attributes.push(valid_attribute);
     }
-    println!("{},", tab_in(depth +1));
+    element_attributes.push( format!("{},", tab_in(depth +1)));
+    return element_attributes;
 }
 
-    fn print_valid_attribute( depth: usize, attribute: xml::attribute::OwnedAttribute) {
+    fn valid_attribute( depth: usize, attribute: xml::attribute::OwnedAttribute) -> String {
         let temp_attribute: String = format!("{}", attribute);
         let parsed_attribute: String = parse_off_extra_w3c_details(temp_attribute);
         let transformed_attribute: String = format!("{}",transform_attribute(parsed_attribute));
         if transformed_attribute != ""{
-            println!("{}{}", tab_in(depth + 1), transformed_attribute);
+            return format!("{}{}", tab_in(depth + 1), transformed_attribute).to_string();
         }
+    return "".to_string();
     }
 
 

--- a/lib/parser/element.rs
+++ b/lib/parser/element.rs
@@ -20,27 +20,30 @@ pub fn build_element(name: xml::name::OwnedName,
 
     let temp_name: String = format!("{}", name);
     let svg_tag: String = parse_off_extra_w3c_details(temp_name);
-    let element_with_attributes: Vec<String> = print_element(svg_tag, attributes, depth);
+    let element_with_attributes: Vec<String> = element(svg_tag, attributes, depth);
     return element_with_attributes.clone();
 }
 
-    fn print_element(svg_tag: String,
+    fn element(svg_tag: String,
                            attributes: Vec<xml::attribute::OwnedAttribute>,
                            depth: usize) -> Vec<String>{
         let mut valid_element_and_attributes: Vec<String> = vec!("".to_string());
         if valid_react_dom_element(&svg_tag) {
-            valid_element_and_attributes = print_valid_element_and_attributes(svg_tag, attributes, depth);
+            valid_element_and_attributes = element_and_attributes(svg_tag, attributes, depth);
         }
         return valid_element_and_attributes;
     }
 
-        fn print_valid_element_and_attributes(svg_tag: String,
+        fn element_and_attributes(svg_tag: String,
                            attributes: Vec<xml::attribute::OwnedAttribute>,
                            depth: usize) -> Vec<String>{
 
-            let dom_element: Vec<String> = vec!(format!("{}React.DOM.{}", tab_in(depth), svg_tag));
+            let mut dom_element: Vec<String> = vec!(format!("{}React.DOM.{}", tab_in(depth), svg_tag));
 
-            build_attributes(attributes.clone(), depth);
+            let dom_element_attributes: Vec<String> = build_attributes(attributes.clone(), depth);
+            for attribute in dom_element_attributes {
+                dom_element.push(attribute);
+            }
 
             return dom_element;
         }

--- a/lib/parser/element.rs
+++ b/lib/parser/element.rs
@@ -4,29 +4,43 @@ use parser::util::tab_in;
 use parser::util::parse_off_extra_w3c_details;
 use parser::util::valid_react_dom_element;
 
+pub fn is_valid_element(name: xml::name::OwnedName) -> bool {
+    let temp_name: String = format!("{}", name);
+    let svg_tag: String = parse_off_extra_w3c_details(temp_name);
+    if valid_react_dom_element(&svg_tag) {
+        return true
+    }
+    return false
+}
+
+
 pub fn build_element(name: xml::name::OwnedName,
                  attributes: Vec<xml::attribute::OwnedAttribute>,
-                 depth: usize) -> bool{
+                 depth: usize) -> Vec<String>{
 
     let temp_name: String = format!("{}", name);
     let svg_tag: String = parse_off_extra_w3c_details(temp_name);
-    return print_element(svg_tag, attributes, depth);
+    let element_with_attributes: Vec<String> = print_element(svg_tag, attributes, depth);
+    return element_with_attributes.clone();
 }
 
     fn print_element(svg_tag: String,
                            attributes: Vec<xml::attribute::OwnedAttribute>,
-                           depth: usize) -> bool {
+                           depth: usize) -> Vec<String>{
+        let mut valid_element_and_attributes: Vec<String> = vec!("".to_string());
         if valid_react_dom_element(&svg_tag) {
-            print_valid_element_and_attributes(svg_tag, attributes, depth);
-            return true
-        } else {
-            return false
+            valid_element_and_attributes = print_valid_element_and_attributes(svg_tag, attributes, depth);
         }
+        return valid_element_and_attributes;
     }
 
         fn print_valid_element_and_attributes(svg_tag: String,
                            attributes: Vec<xml::attribute::OwnedAttribute>,
-                           depth: usize) {
-            println!("{}React.DOM.{}", tab_in(depth), svg_tag);
+                           depth: usize) -> Vec<String>{
+
+            let mut dom_element: Vec<String> = vec!(format!("{}React.DOM.{}", tab_in(depth), svg_tag));
+
             build_attributes(attributes.clone(), depth);
+
+            return dom_element;
         }

--- a/lib/parser/element.rs
+++ b/lib/parser/element.rs
@@ -38,7 +38,7 @@ pub fn build_element(name: xml::name::OwnedName,
                            attributes: Vec<xml::attribute::OwnedAttribute>,
                            depth: usize) -> Vec<String>{
 
-            let mut dom_element: Vec<String> = vec!(format!("{}React.DOM.{}", tab_in(depth), svg_tag));
+            let dom_element: Vec<String> = vec!(format!("{}React.DOM.{}", tab_in(depth), svg_tag));
 
             build_attributes(attributes.clone(), depth);
 

--- a/lib/parser/parser.rs
+++ b/lib/parser/parser.rs
@@ -10,7 +10,7 @@ use xml::reader::events::*;
 pub fn parse_svg (file_name: String, header_string: String) -> Vec<String>{
 
     let file = get_file(file_name);
-    let output_vector: Vec<String> = vec!();
+    let mut output_vector: Vec<String> = vec!(header_string);
     let mut parser = EventReader::new(file);
 
     // let mut output_vector: Vec<String> = [""];
@@ -21,9 +21,11 @@ pub fn parse_svg (file_name: String, header_string: String) -> Vec<String>{
     for e in parser.events() {
         match e {
             XmlEvent::StartElement { name, attributes, .. } => {
-                let mut element_vector: Vec<String> = build_element(name, attributes, depth);
-                output_vector.push_all(element_vector.to_vec());
-                was_valid_element = is_valid_element(name);
+                let element_vector: Vec<String> = build_element(name.clone(), attributes, depth);
+                for completed_element in element_vector {
+                    output_vector.push(completed_element.clone());
+                }
+                was_valid_element = is_valid_element(name.clone());
                 depth += 1;
             }
             XmlEvent::EndElement { .. } => {

--- a/lib/parser/parser.rs
+++ b/lib/parser/parser.rs
@@ -35,7 +35,9 @@ pub fn parse_svg (file_name: String, header_string: String) -> Vec<String>{
                 if was_valid_element {
                     depth += 1;
                     if !data.contains(">") {
-                        println!("{}\"{}\"\n\n", tab_in(depth), data.to_string());
+                        let valid_data: String = format!("{}\"{}\"\n\n", tab_in(depth), data.to_string());
+                        output_vector.push(valid_data);
+
                     }
                     depth -= 1;
                 }

--- a/lib/parser/parser.rs
+++ b/lib/parser/parser.rs
@@ -7,17 +7,23 @@ use xml::reader::EventReader;
 use xml::reader::events::*;
 
 
-pub fn parse_svg (file_name: String){
+pub fn parse_svg (file_name: String, header_string: String) -> Vec<String>{
 
     let file = get_file(file_name);
+    let output_vector: Vec<String> = vec!();
     let mut parser = EventReader::new(file);
+
+    // let mut output_vector: Vec<String> = [""];
 
     let mut depth = 2;
     let mut was_valid_element = false;
+
     for e in parser.events() {
         match e {
             XmlEvent::StartElement { name, attributes, .. } => {
-                was_valid_element = build_element(name, attributes, depth);
+                let mut element_vector: Vec<String> = build_element(name, attributes, depth);
+                output_vector.push_all(element_vector.to_vec());
+                was_valid_element = is_valid_element(name);
                 depth += 1;
             }
             XmlEvent::EndElement { .. } => {
@@ -35,4 +41,5 @@ pub fn parse_svg (file_name: String){
             _ => {}
         }
     }
+    return output_vector;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,5 +7,8 @@ fn main() {
     let svg_file: Vec<_> = env::args().collect();
     let file_name: String = svg_file[1].to_string();
     let full_file_path_and_name = format!("{}/{}",env::current_dir().unwrap().display(),file_name);
-    convert(full_file_path_and_name.clone());
+    let converted_data = convert(full_file_path_and_name.clone());
+    for data in converted_data {
+        println!("{}", data);
+    }
 }


### PR DESCRIPTION
_What it does_
Refactors out the need to print out to the command line for any kind of error. Currently returns a Vector.
Binary still dumps directly to the console.

_Why it does it_
Makes it more universal for connecting with other interfaces.
